### PR TITLE
lsp server setup for navbuddy 

### DIFF
--- a/lua/custom/plugins/navbuddy.lua
+++ b/lua/custom/plugins/navbuddy.lua
@@ -7,6 +7,15 @@ return {
         'SmiteshP/nvim-navic',
         'MunifTanjim/nui.nvim',
       },
+      keys = {
+        {
+          '<leader>nv',
+          function()
+            require('nvim-navbuddy').open()
+          end,
+          desc = 'Open Navbuddy',
+        },
+      },
       opts = { lsp = { auto_attach = true } },
       config = function()
         local navbuddy = require("nvim-navbuddy")
@@ -100,20 +109,42 @@ return {
             }),
             ["g?"] = actions.help(),
           },
-          lsp = {
-            auto_attach = false,
+         lsp = {
+            auto_attach = true,
             preference = nil,
           },
           source_buffer = {
             follow_node = true,
             highlight = true,
             reorient = "smart",
-            scrolloff = nil
+            scrolloff = nil,
           },
           custom_hl_group = nil,
         }
       end,
     },
   },
-  -- your lsp config or other stuff
+
+  config = function()
+    --  LSP serverconfig for navbuddy to work
+    local lspconfig = require 'lspconfig'
+
+    lspconfig.lua_ls.setup {
+      settings = {
+        Lua = {
+          diagnostics = {
+            globals = { 'vim' },
+          },
+          workspace = {
+            library = vim.api.nvim_get_runtime_file('', true),
+            checkThirdParty = false,
+          },
+        },
+      },
+    }
+
+    lspconfig.pyright.setup {}
+    lspconfig.ts_ls.setup {}
+    lspconfig.clangd.setup {}
+  end,
 }


### PR DESCRIPTION
This pull request enhances the configuration of the `nvim-navbuddy` plugin by adding a convenient keybinding and updating the LSP server setup to improve integration and usability. The most important changes are grouped below:

**Keybinding Addition:**

* Added a keybinding (`<leader>nv`) to quickly open Navbuddy, making it easier to access the plugin.

**LSP Integration Improvements:**

* Changed the Navbuddy LSP option `auto_attach` from `false` to `true`, allowing automatic attachment to supported language servers for better navigation features.
* Added a configuration block to set up LSP servers (`lua_ls`, `pyright`, `ts_ls`, and `clangd`) with specific settings for Lua diagnostics and workspace, ensuring Navbuddy works seamlessly with these languages.